### PR TITLE
Implemented movement for individual Paddles

### DIFF
--- a/Assets/Prefabs/Paddle.prefab
+++ b/Assets/Prefabs/Paddle.prefab
@@ -31,7 +31,7 @@ Transform:
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 3, z: 1}
+  m_LocalScale: {x: 1, y: 5, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
@@ -147,4 +147,4 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   speed: 300
-  isLeftPaddle: 0
+  owner: 0

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -169,6 +169,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8a2e2285611ea7c42955b28bf4cdb2f6, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  paddlePrefab: {fileID: 8632520244467056536, guid: c342b674017092945864cdb6f51a1b5a, type: 3}
 --- !u!4 &347909306 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 6748362094357036627, guid: 9374a0eb31ff5f441825e7e298b38b68, type: 3}
@@ -638,6 +639,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: RightPaddle
       objectReference: {fileID: 0}
+    - target: {fileID: 5966460280710027105, guid: c342b674017092945864cdb6f51a1b5a, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 8065107347238726498, guid: c342b674017092945864cdb6f51a1b5a, type: 3}
       propertyPath: m_LocalScale.y
       value: 5
@@ -794,9 +799,9 @@ PrefabInstance:
       propertyPath: m_Name
       value: LeftPaddle
       objectReference: {fileID: 0}
-    - target: {fileID: 8065107347238726498, guid: c342b674017092945864cdb6f51a1b5a, type: 3}
-      propertyPath: m_LocalScale.y
-      value: 5
+    - target: {fileID: 5966460280710027105, guid: c342b674017092945864cdb6f51a1b5a, type: 3}
+      propertyPath: m_IsActive
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8065107347238726498, guid: c342b674017092945864cdb6f51a1b5a, type: 3}
       propertyPath: m_LocalPosition.x

--- a/Assets/Scripts/Paddle.cs
+++ b/Assets/Scripts/Paddle.cs
@@ -17,7 +17,7 @@ public class Paddle : MonoBehaviour
 
     void FixedUpdate()
     {
-        float verticalValue = Input.GetAxis("Vertical");
+        float verticalValue = owner == Player.Left ?  Input.GetAxis("LeftPaddle") : Input.GetAxis("RightPaddle");
 
         Vector3 force = new Vector3(transform.position.x, verticalValue, transform.position.y) * speed;
         //transform.position += new Vector3(transform.position.x, verticalValue, transform.position.z) * speed * Time.deltaTime;

--- a/Assets/Scripts/Paddle.cs
+++ b/Assets/Scripts/Paddle.cs
@@ -8,11 +8,11 @@ public class Paddle : MonoBehaviour
     private Rigidbody rb;
     public float speed;
     private Vector3 _bounceDirection;
-    public bool isLeftPaddle;
+    public Player owner;
     private void Start()
     {
         rb = GetComponent<Rigidbody>();
-        _bounceDirection = isLeftPaddle ? Vector3.right : Vector3.left; 
+        _bounceDirection = owner == Player.Left ? Vector3.right : Vector3.left; 
     }
 
     void FixedUpdate()
@@ -23,6 +23,12 @@ public class Paddle : MonoBehaviour
         //transform.position += new Vector3(transform.position.x, verticalValue, transform.position.z) * speed * Time.deltaTime;
 
         rb.AddForce(force, ForceMode.Force);
+    }
+
+    public void SetTeam(Player player)
+    {
+        owner = player;
+        _bounceDirection = owner == Player.Left ? Vector3.right : Vector3.left;
     }
 
     private void OnCollisionEnter(Collision collision)

--- a/Assets/Scripts/PaddleManager.cs
+++ b/Assets/Scripts/PaddleManager.cs
@@ -4,5 +4,24 @@ using UnityEngine;
 
 public class PaddleManager : MonoBehaviour
 {
-    
+    [SerializeField] Paddle paddlePrefab;
+    private Paddle leftPaddle;
+    private Paddle rightPaddle;
+
+    private void Awake()
+    {
+        StartCoroutine(CreatePaddles());
+    }
+
+    private IEnumerator CreatePaddles()
+    {
+        Vector2 spawnPos = new Vector2(23.5f, 0f);
+        leftPaddle = Instantiate(paddlePrefab, -spawnPos, paddlePrefab.transform.rotation);
+        leftPaddle.SetTeam(Player.Left);
+
+        yield return new WaitForSeconds(0.2f);
+
+        rightPaddle = Instantiate(paddlePrefab, spawnPos, paddlePrefab.transform.rotation);
+        rightPaddle.SetTeam(Player.Right);
+    }
 }

--- a/ProjectSettings/InputManager.asset
+++ b/ProjectSettings/InputManager.asset
@@ -22,13 +22,13 @@ InputManager:
     axis: 0
     joyNum: 0
   - serializedVersion: 3
-    m_Name: Vertical
+    m_Name: LeftPaddle
     descriptiveName: 
     descriptiveNegativeName: 
-    negativeButton: down
-    positiveButton: up
-    altNegativeButton: s
-    altPositiveButton: w
+    negativeButton: s
+    positiveButton: w
+    altNegativeButton: 
+    altPositiveButton: 
     gravity: 3
     dead: 0.001
     sensitivity: 3
@@ -38,17 +38,17 @@ InputManager:
     axis: 0
     joyNum: 0
   - serializedVersion: 3
-    m_Name: Fire1
+    m_Name: RightPaddle
     descriptiveName: 
     descriptiveNegativeName: 
-    negativeButton: 
-    positiveButton: left ctrl
+    negativeButton: down
+    positiveButton: up
     altNegativeButton: 
     altPositiveButton: mouse 0
-    gravity: 1000
+    gravity: 3
     dead: 0.001
-    sensitivity: 1000
-    snap: 0
+    sensitivity: 3
+    snap: 1
     invert: 0
     type: 0
     axis: 0
@@ -269,6 +269,22 @@ InputManager:
     positiveButton: enter
     altNegativeButton: 
     altPositiveButton: space
+    gravity: 1000
+    dead: 0.001
+    sensitivity: 1000
+    snap: 0
+    invert: 0
+    type: 0
+    axis: 0
+    joyNum: 0
+  - serializedVersion: 3
+    m_Name: Cancel
+    descriptiveName: 
+    descriptiveNegativeName: 
+    negativeButton: 
+    positiveButton: escape
+    altNegativeButton: 
+    altPositiveButton: joystick button 1
     gravity: 1000
     dead: 0.001
     sensitivity: 1000


### PR DESCRIPTION
The left paddle now moves using the "S" and "W" keys, while the right paddle moves using the "Up" and "Down" arrow keys.
Both paddles have an instance of the same script for movement.
This fixes #3.